### PR TITLE
Separating topology definition from use

### DIFF
--- a/rabbus/lib/consumer/index.js
+++ b/rabbus/lib/consumer/index.js
@@ -14,7 +14,6 @@ function Consumer(rabbit, options, defaults){
   EventEmitter.call(this);
 
   this.rabbit = rabbit;
-  this.options = options;
   this.topology = new Topology(rabbit, options, defaults);
 
   this.middlewareBuilder = new MiddlewareBuilder(["msg", "props", "actions"]);
@@ -45,7 +44,7 @@ Consumer.prototype.stop = function(){
 Consumer.prototype.consume = function(cb){
   var rabbit = this.rabbit;
   var queue = this.topology.queue.name;
-  var messageType = this.options.messageType || this.options.routingKey;
+  var messageType = this.topology.messageType || this.topology.routingKey;
 
   this.topology.execute((err) => {
     if (err) { return this.emitError(err); }

--- a/rabbus/lib/producer/index.js
+++ b/rabbus/lib/producer/index.js
@@ -15,11 +15,7 @@ function Producer(rabbit, options, defaults){
 
   this.rabbit = rabbit;
   this.options = options;
-
-  var topologyConfig = {
-    exchange: options.exchange
-  };
-  this.topology = new Topology(rabbit, topologyConfig, defaults);
+  this.topology = new Topology(rabbit, options, defaults);
 
   this.middlewareBuilder = new MiddlewareBuilder(["msg", "hdrs"]);
 }

--- a/rabbus/lib/producer/index.js
+++ b/rabbus/lib/producer/index.js
@@ -14,7 +14,6 @@ function Producer(rabbit, options, defaults){
   EventEmitter.call(this);
 
   this.rabbit = rabbit;
-  this.options = options;
   this.topology = new Topology(rabbit, options, defaults);
 
   this.middlewareBuilder = new MiddlewareBuilder(["msg", "hdrs"]);
@@ -104,7 +103,7 @@ function producer(publishMethod){
       properties.onComplete = undefined;
     }
 
-    var options = this.options;
+    var topology = this.topology;
 
     // start the message producer
     this.topology.execute((err) => {
@@ -115,14 +114,14 @@ function producer(publishMethod){
       var middleware = this.middlewareBuilder.build((message, middlewareHeaders, next) => {
         var headers = _.extend({}, middlewareHeaders, properties.headers);
 
-        var messageType = options.messageType || options.routingKey;
+        var messageType = topology.messageType || topology.routingKey;
         var props = _.extend({}, properties, {
-          routingKey: options.routingKey,
+          routingKey: topology.routingKey,
           type: messageType,
           headers: headers
         });
 
-        logger.info("Publishing Message With Routing Key '" + options.routingKey + "'");
+        logger.info("Publishing Message With Routing Key '" + topology.routingKey + "'");
         logger.debug("With Properties");
         logger.debug(props);
 

--- a/rabbus/lib/topology/index.js
+++ b/rabbus/lib/topology/index.js
@@ -20,6 +20,23 @@ function Topology(rabbit, options, defaults){
   this.routingKey = this.options.routingKey;
 }
 
+// Type Members
+// ------------
+
+Topology.verify = function(rabbit, options, defaults, cb){
+  var topology;
+
+  if (isTopology(options)){
+    topology = options;
+    cb(undefined, topology);
+  } else {
+    topology = new Topology(rabbit, options, defaults);
+    topology.execute((err) => {
+      return cb(err, topology);
+    });
+  }
+};
+
 // Public Members
 // --------------
 
@@ -93,6 +110,15 @@ Topology.prototype._addBinding = function(ex, q, routingKey){
   var bP = this.rabbit.bindQueue(ex, q, routingKey);
   return bP;
 };
+
+// Helpers
+// -------
+
+function isTopology(obj){
+  if (!obj){ return false; }
+  var type = typeof obj.execute;
+  return (type.toLowerCase() === "function");
+}
 
 // Exports
 // -------

--- a/rabbus/lib/topology/index.js
+++ b/rabbus/lib/topology/index.js
@@ -13,6 +13,8 @@ function Topology(rabbit, options, defaults){
   this.rabbit = rabbit;
   this.options = OptionParser.parse(options, defaults);
 
+  this.routingKey = this.options.routingKey;
+  this.messageType = this.options.messageType;
   this.exchange = this.options.exchange;
   this.queue = this.options.queue;
   this.routingKey = this.options.routingKey;

--- a/rabbus/lib/topology/index.js
+++ b/rabbus/lib/topology/index.js
@@ -1,0 +1,46 @@
+var EventEmitter = require("events").EventEmitter;
+var util = require("util");
+
+var logger = require("../logging")("rabbus.topology");
+var OptionParser = require("../optionParser");
+
+// Topology
+// --------
+
+function Topology(rabbit, options, defaults){
+  this.rabbit = rabbit;
+  this.options = OptionParser.parse(options, defaults);
+  this.exchange = this.options.exchange;
+}
+
+// Public Members
+// --------------
+
+Topology.prototype.execute = function(cb){
+  this._start().then(() => {
+    return cb(undefined, this.options);
+  })
+  .catch((err) => {
+    return cb(err);
+  });
+};
+
+// Private Members
+// ---------------
+
+Topology.prototype._start = function(){
+  if (this._startPromise){ return this._startPromise; }
+  var exchange = this.options.exchange;
+
+  logger.info("Declaring exchange", exchange.name);
+  logger.debug("With Exchange Options", exchange);
+
+  this._startPromise = this.rabbit.addExchange(exchange.name, exchange.type, exchange);
+
+  return this._startPromise;
+};
+
+// Exports
+// -------
+
+module.exports = Topology;

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -1,0 +1,91 @@
+var rabbit = require("wascally");
+
+var Topology = require("../lib/topology");
+var Sender = require("../lib/send-rec/sender");
+var Receiver = require("../lib/send-rec/receiver");
+
+function reportErr(err){
+  setImmediate(function(){
+    console.log(err.stack);
+    throw err;
+  });
+}
+
+fdescribe("topology", function(){
+  var msgType1 = "send-receive.messageType.1";
+  var ex1 = "send-receive.ex.1";
+  var q1 = "send-receive.q.1";
+  var rKey = "test.key";
+
+  var exchangeConfig = {
+    name: ex1,
+    autoDelete: true
+  };
+
+  describe("given preconfigured topologies, when sending a message", function(){
+    var msg1, send, rec;
+    var sendHandled, recHandled;
+    var sendMessage;
+
+    beforeEach(function(done){
+      msg1 = {foo: "bar"};
+
+      var sendTopology = new Topology(rabbit, {
+        exchange: exchangeConfig,
+        messageType: msgType1,
+        routingKey: rKey
+      });
+
+      var receiveTopology = new Topology(rabbit, {
+        exchange: exchangeConfig,
+        queue: {
+          name: q1,
+          autoDelete: true
+        },
+        messageType: msgType1,
+        routingKey: rKey
+      });
+
+      var sP = new Promise(function(res, rej){
+        sendTopology.execute(function(err){
+          if (err) { return rej(err); }
+          res();
+        });
+      });
+
+      var rP = new Promise(function(res, rej){
+        receiveTopology.execute(function(err){
+          if (err) { return rej(err); }
+          res();
+        });
+      });
+
+      Promise.all([sP, rP]).then(function(){
+        var preConfigSendTop = new Topology(rabbit, {
+          queue: q1
+        });
+        send = new Sender(rabbit, preConfigSendTop);
+        send.on("error", reportErr);
+
+        var preConfigRecTop = new Topology(rabbit, {
+          exchange: ex1
+        });
+        rec = new Receiver(rabbit, preConfigRecTop);
+        rec.on("error", reportErr);
+
+        rec.receive(function(msg, properties, actions){
+          sendMessage = msg;
+          actions.ack();
+          done();
+        });
+
+        send.send(msg1);
+      }).catch(reportErr);
+    });
+
+    it("receiver should receive the message", function(){
+      expect(sendMessage.foo).toBe(msg1.foo);
+    });
+
+  });
+});

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -62,13 +62,17 @@ fdescribe("topology", function(){
 
       Promise.all([sP, rP]).then(function(){
         var preConfigSendTop = new Topology(rabbit, {
-          exchange: ex1
+          exchange: ex1,
+          messageType: msgType1,
+          routingKey: rKey
         });
         send = new Sender(rabbit, preConfigSendTop);
         send.on("error", reportErr);
 
         var preConfigRecTop = new Topology(rabbit, {
-          queue: q1
+          queue: q1,
+          messageType: msgType1,
+          routingKey: rKey
         });
         rec = new Receiver(rabbit, preConfigRecTop);
         rec.on("error", reportErr);

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -71,8 +71,7 @@ describe("topology", function(){
 
         var preConfigRecTop = new Topology(rabbit, {
           queue: q1,
-          messageType: msgType1,
-          routingKey: rKey
+          messageType: msgType1
         });
         rec = new Receiver(rabbit, preConfigRecTop);
         rec.on("error", reportErr);

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -12,9 +12,9 @@ function reportErr(err){
 }
 
 fdescribe("topology", function(){
-  var msgType1 = "send-receive.messageType.1";
-  var ex1 = "send-receive.ex.1";
-  var q1 = "send-receive.q.1";
+  var msgType1 = "preconfigured.messageType.1";
+  var ex1 = "preconfigured.ex.1";
+  var q1 = "preconfigured.q.1";
   var rKey = "test.key";
 
   var exchangeConfig = {
@@ -62,13 +62,13 @@ fdescribe("topology", function(){
 
       Promise.all([sP, rP]).then(function(){
         var preConfigSendTop = new Topology(rabbit, {
-          queue: q1
+          exchange: ex1
         });
         send = new Sender(rabbit, preConfigSendTop);
         send.on("error", reportErr);
 
         var preConfigRecTop = new Topology(rabbit, {
-          exchange: ex1
+          queue: q1
         });
         rec = new Receiver(rabbit, preConfigRecTop);
         rec.on("error", reportErr);

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -30,23 +30,13 @@ fdescribe("topology", function(){
     beforeEach(function(done){
       msg1 = {foo: "bar"};
 
-      var sendTopology = new Topology(rabbit, {
-        exchange: exchangeConfig,
-        messageType: msgType1,
-        routingKey: rKey
-      });
-
-      var receiveTopology = new Topology(rabbit, {
-        exchange: exchangeConfig,
-        queue: {
-          name: q1,
-          autoDelete: true
-        },
-        messageType: msgType1,
-        routingKey: rKey
-      });
-
       var sP = new Promise(function(res, rej){
+        var sendTopology = new Topology(rabbit, {
+          exchange: exchangeConfig,
+          messageType: msgType1,
+          routingKey: rKey
+        });
+
         sendTopology.execute(function(err){
           if (err) { return rej(err); }
           res();
@@ -54,6 +44,16 @@ fdescribe("topology", function(){
       });
 
       var rP = new Promise(function(res, rej){
+        var receiveTopology = new Topology(rabbit, {
+          exchange: exchangeConfig,
+          queue: {
+            name: q1,
+            autoDelete: true
+          },
+          messageType: msgType1,
+          routingKey: rKey
+        });
+
         receiveTopology.execute(function(err){
           if (err) { return rej(err); }
           res();

--- a/rabbus/specs/topology.specs.js
+++ b/rabbus/specs/topology.specs.js
@@ -11,7 +11,7 @@ function reportErr(err){
   });
 }
 
-fdescribe("topology", function(){
+describe("topology", function(){
   var msgType1 = "preconfigured.messageType.1";
   var ex1 = "preconfigured.ex.1";
   var q1 = "preconfigured.q.1";


### PR DESCRIPTION
Per conversation in #2, I've made a first attempt at pulling the topology definition out of the message producer and consumer base types. 

I'm looking for feedback on the current implementation and requirements, for the code in this pull request.
## Drop-In Replacement

At the moment, this should be a drop-in replacement for current Rabbus use and I want to keep it that way as much as possible... but I recognize that this may not be possible, given some of the code cleanliness issues I've noted below.

Right now, you'll still be able to write code like this:

``` js
new Rabbus.Sender(wascally, {
  exchange: exchangeConfig,
  messageType: msgType,
  routingKey: rKey
});
```

This code will create the topology for you, internally, as Rabbus does now. 
## Execute Extracted Topology

What this change provides, though, is the ability to separate the topology configuration so that your message producers and consumers are not required to define the topology directly.

For example,

``` js
// define the topology
// -------------------------

var topology = new Rabbus.Topology(wascally, {
  exchange: exchangeConfig,
  messageType: msgType,
  routingKey: rKey
});

// execute the topology against rabbitmq
// ---------------------------------------------------

topology.execute(function(err){

  // now use the topology in a message producer or consumer
  var sender = new Rabbus.Sender(wascally, topology);

  // ...
});
```
## Use Pre-defined Topology

With the ability to extract the topology definition, you also have the option of not executing it against RabbitMQ. This would allow you to use existing topology definitions in your RabbitMQ server, and use the wascally configuration options to a greater extent.

``` js
// define the topology
// -------------------------

var topology = new Rabbus.Topology(wascally, {
  exchange: exchangeConfig,
  messageType: msgType,
  routingKey: rKey
});

// don't execute it because we know rmq already has it
// just use the topology, as is
// ---------------------------------------------------------------------

var sender = new Rabbus.Sender(wascally, topology);
```
## Potential Areas I Don't Like

There are a few things I don't like about the way this works, right now, most of which is out of my control I think.
#### Passing wascally Everywhere

First off, you have to pass a `wascally` object into the Topology and the Sender, as shown above. 

This is needed in the Topology so it can wascally to define the topology on RMQ. It's also needed in the Sender so that it can send the message across. 

It might be nice to not require passing `wascally` to every object instance, all the time ... but this seems a minor thing.
#### Required Message Type For Topology

Due to the way wascally works with message types, at the moment, you're required to provide a message types, you're still required to provide a message type for a producer and consumer topology configuration, even if this is a predefined topology.

``` js
var preConfigSendTop = new Topology(rabbit, {
  exchange: ex1,
  messageType: msgType1,
  routingKey: rKey
});

var sender = new Sender(rabbit, preConfigSendTop);

var preConfigRecTop = new Topology(rabbit, {
  queue: q1,
  messageType: msgType1
});

rec = new Receiver(rabbit, preConfigRecTop);
```

This requirement for a message type may change with the next major release of wascally, but i haven't tested it against that new fork/branch, yet. 
### Required Routing Key For Message Producer

With the current code, you must provide a Routing Key to the topology for a message producer.

``` js
var preConfigSendTop = new Topology(rabbit, {
  exchange: ex1,
  messageType: msgType1,
  routingKey: rKey
});

var sender = new Sender(rabbit, preConfigSendTop);
```

This doesn't make sense to me, from an API perspective. It's the `Sender` that needs to know about the routing key (and message type, for that matter), not the topology.

I had a hard time keeping the code implementation clean when I tried to move the `routingKey` and `messageType` into the message producer base type
#### Misc Other Bits

There are probably some misc other bits in the code that I'm not super comfortable with, mostly related to separation of concerns like the message type and routing keys, and/or keeping code clean.
## Feedback Needed

I'd like to get feedback on the code in this pull request, the items I've noted above, etc. 

You can see the new Topology object here: https://github.com/derickbailey/rabbus/blob/topology/rabbus/lib/topology/index.js

And there are basic specs for re-using existing topology here: https://github.com/derickbailey/rabbus/blob/topology/rabbus/specs/topology.specs.js

Use of the topology in the base producer and consumer are here:
- consumer: https://github.com/derickbailey/rabbus/blob/topology/rabbus/lib/consumer/index.js#L84
- producer: https://github.com/derickbailey/rabbus/blob/topology/rabbus/lib/producer/index.js#L89
